### PR TITLE
git clone: show progress + shallow clone

### DIFF
--- a/deps/cutter/CMakeLists.txt
+++ b/deps/cutter/CMakeLists.txt
@@ -5,6 +5,8 @@ include(FetchContent)
 FetchContent_Declare(cutter
 	GIT_REPOSITORY https://github.com/radareorg/cutter
 	GIT_TAG master
+	GIT_PROGRESS TRUE
+	GIT_SHALLOW TRUE
 )
 
 FetchContent_GetProperties(cutter)

--- a/deps/retdec/CMakeLists.txt
+++ b/deps/retdec/CMakeLists.txt
@@ -4,7 +4,9 @@ include(FetchContent)
 
 FetchContent_Declare(retdec
 	GIT_REPOSITORY https://github.com/avast/retdec
-	GIT_TAG 73184b0c17b8790ab691217d2ab4cb6d569495fb
+	GIT_TAG 73184b0c17b8790ab691217d2ab4cb6d569495fb # TODO use branch_name or tag_name
+	GIT_PROGRESS TRUE
+	#GIT_SHALLOW TRUE # requires GIT_TAG to be branch_name or tag_name
 )
 
 FetchContent_GetProperties(retdec)


### PR DESCRIPTION
show progress
slow connections need some seconds to download
currently, git clone is silent, so it looks like it hangs
also, with silent clone, there is no info before (potentially large) downloads

shallow clone
reduce transfer size + disk use

todo
set version with branch_name or tag_name
to make shallow-clone work
